### PR TITLE
write_event: Remove ineffective operations

### DIFF
--- a/rftrace-frontend/src/frontend.rs
+++ b/rftrace-frontend/src/frontend.rs
@@ -340,10 +340,8 @@ fn write_event(out: &mut Vec<u8>, time: u64, addr: *const usize, kind: u64) {
         .expect("Write interrupted");
 
     let mut merged: u64 = 0;
-    merged |= (kind & 0b11) << 0; // type = UFTRACE_EXIT / UFTRACE_ENTRY
-    merged |= 0 << 2; // more, always 0
+    merged |= kind & 0b11; // type = UFTRACE_EXIT / UFTRACE_ENTRY
     merged |= 0b101 << 3; // magic, always 0b101
-    merged |= (0 & ((1 << 10) - 1)) << 6; // depth
     merged |= (addr as u64 & ((1 << 48) - 1)) << 16; // actual address, limited to 48 bit.
     out.write_u64::<LittleEndian>(merged)
         .expect("Write interrupted");


### PR DESCRIPTION
I am not sure if removing line 346 is the proper fix here, what do you think, @tlambertz?

Fixes
```
error: this operation will always return zero. This is likely not the intended outcome
   --> rftrace-frontend/src/frontend.rs:346:15
    |
346 |     merged |= (0 & ((1 << 10) - 1)) << 6; // depth
    |               ^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[deny(clippy::erasing_op)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#erasing_op
```
and
```
warning: the operation is ineffective. Consider reducing it to `(kind & 0b11)`
   --> rftrace-frontend/src/frontend.rs:343:15
    |
343 |     merged |= (kind & 0b11) << 0; // type = UFTRACE_EXIT / UFTRACE_ENTRY
    |               ^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(clippy::identity_op)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#identity_op
```