### PR TITLE
Rename to x86_64-unknown-none-hermitkernel

### DIFF
--- a/rftrace/Cargo.toml
+++ b/rftrace/Cargo.toml
@@ -20,8 +20,8 @@ include = [
 
 
 [features]
-buildcore = [] # Build core, needed when compiling against a kernel-target, such as x86_64-unknown-hermit-kernel.
-autokernel = [] # convenience flag, which specifies compilation target as `x86_64-unknown-hermit-kernel` when orignal target is `x86_64-unknown-hermit`
+buildcore = [] # Build core, needed when compiling against a kernel-target, such as x86_64-unknown-none-hermitkernel.
+autokernel = [] # convenience flag, which specifies compilation target as `x86_64-unknown-none-hermitkernel` when orignal target is `x86_64-unknown-hermit`
 interruptsafe = [] # backup and restore all scratch registers in the mcount_return trampoline. Needed if we instrument interrupt routines
 
 default = ['interruptsafe']

--- a/rftrace/build.rs
+++ b/rftrace/build.rs
@@ -41,7 +41,7 @@ fn build_backend() {
             return default;
             #[cfg(feature = "autokernel")]
             if default == "x86_64-unknown-hermit" {
-                return "x86_64-unknown-hermit-kernel".to_owned();
+                return "x86_64-unknown-none-hermitkernel".to_owned();
             } else {
                 return default;
             }
@@ -83,7 +83,7 @@ fn build_backend() {
     cmd.stdout(Stdio::inherit());
     cmd.stderr(Stdio::inherit());
 
-    // Build core, needed when compiling against a kernel-target, such as x86_64-unknown-hermit-kernel.
+    // Build core, needed when compiling against a kernel-target, such as x86_64-unknown-none-hermitkernel.
     // parent's cargo does NOT expose -Z flags as envvar, we therefore use a feature flag for this
     #[cfg(feature = "buildcore")]
     cmd.args(&["-Z", "build-std=core"]); // should be build std,alloc?


### PR DESCRIPTION
This adapts the new RustyHermit kernel target. See https://github.com/hermitcore/rusty-hermit/commit/c99060528ac069159cfc8baec20eb57de6ec1167 and https://github.com/rust-lang/rust/pull/77916.