### PR TITLE
Restore functionality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  c:
+    name: C
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./examples/c
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uftrace
+        run: |
+          sudo apt-get update
+          sudo apt-get install uftrace
+      - uses: mkroening/rust-toolchain-toml@main
+      - uses: Swatinem/rust-cache@v2
+      - name: Build
+        run: make
+      - name: Run
+        run: |
+          mkdir tracedir
+          ./test
+      - name: Replay
+        run: uftrace replay --data=tracedir --output-fields=tid | tee ci.snap
+      - name: Compare to snapshot
+        run: diff ci.snap out.snap
+
+  rust:
+    name: Rust
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./examples/rust
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uftrace
+        run: |
+          sudo apt-get update
+          sudo apt-get install uftrace
+      - uses: mkroening/rust-toolchain-toml@main
+      - uses: Swatinem/rust-cache@v2
+      - name: Build
+        run: cargo rustc -- -Zinstrument-mcount -C passes="ee-instrument post-inline-ee-instrument"
+      - name: Run
+        run: |
+          mkdir tracedir
+          ../../target/debug/rftrace-rs-test
+      - name: Replay
+        run: uftrace replay --data=tracedir --output-fields=tid | tee ci.snap
+      - name: Compare to snapshot
+        run: diff ci.snap out.snap

--- a/examples/c/out.snap
+++ b/examples/c/out.snap
@@ -1,0 +1,16 @@
+#   TID     FUNCTION
+ [     1] | func1() {
+ [     1] |   func2() {
+ [     1] |     func3();
+ [     1] |   } /* func2 */
+ [     1] | } /* func1 */
+ [     1] | func1() {
+ [     1] |   func2() {
+ [     1] |     func3();
+ [     1] |   } /* func2 */
+ [     1] | } /* func1 */
+ [     1] | func1() {
+ [     1] |   func2() {
+ [     1] |     func3();
+ [     1] |   } /* func2 */
+ [     1] | } /* func1 */

--- a/examples/hermitrust/Cargo.toml
+++ b/examples/hermitrust/Cargo.toml
@@ -8,10 +8,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rftrace = {path="../../rftrace", features=["buildcore","autokernel"]}
-#rftrace = {version="0.1.0", features=["buildcore","autokernel"]}
-rftrace-frontend = {path="../../rftrace-frontend"}
-#rftrace-frontend = "0.1.0"
+rftrace = { version = "0.2.0", path="../../rftrace", features=["buildcore","autokernel"] }
+rftrace-frontend = { version = "0.1.0", path="../../rftrace-frontend" }
 
 
 [target.'cfg(target_os = "hermit")'.dependencies]

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -8,8 +8,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-#rftrace = {path="../../rftrace"}
-rftrace = "0.1.0"
-
-#rftrace-frontend = {path="../../rftrace-frontend"}
-rftrace-frontend = "0.1.0"
+rftrace = { version = "0.2.0", path="../../rftrace" }
+rftrace-frontend = { version = "0.1.0", path="../../rftrace-frontend" }

--- a/examples/rust/out.snap
+++ b/examples/rust/out.snap
@@ -1,0 +1,11 @@
+#   TID     FUNCTION
+ [     1] | core::fmt::Arguments::new_v1();
+ [     1] | rftrace_rs_test::test1() {
+ [     1] |   core::fmt::Arguments::new_v1();
+ [     1] |   rftrace_rs_test::test2() {
+ [     1] |     core::fmt::Arguments::new_v1();
+ [     1] |     rftrace_rs_test::test3() {
+ [     1] |       core::fmt::Arguments::new_v1();
+ [     1] |     } /* rftrace_rs_test::test3 */
+ [     1] |   } /* rftrace_rs_test::test2 */
+ [     1] | } /* rftrace_rs_test::test1 */

--- a/rftrace-frontend/Cargo.toml
+++ b/rftrace-frontend/Cargo.toml
@@ -15,4 +15,4 @@ repository = "https://github.com/tlambertz/rftrace"
 crate-type = ['rlib']
 
 [dependencies]
-byteorder = "1.3.2"
+byteorder = "~1.3.2"

--- a/rftrace/Cargo.toml
+++ b/rftrace/Cargo.toml
@@ -24,7 +24,7 @@ buildcore = [] # Build core, needed when compiling against a kernel-target, such
 autokernel = [] # convenience flag, which specifies compilation target as `x86_64-unknown-none-hermitkernel` when orignal target is `x86_64-unknown-hermit`
 interruptsafe = [] # backup and restore all scratch registers in the mcount_return trampoline. Needed if we instrument interrupt routines
 
-default = ['interruptsafe']
+default = []
 
 [lib]
 crate-type = ['staticlib', 'rlib']

--- a/rftrace/build.rs
+++ b/rftrace/build.rs
@@ -50,8 +50,6 @@ fn build_backend() {
     println!("Compiling for target {}", target);
 
     let mut cmd = Command::new("cargo");
-    // We use nightly features, so always enable it
-    cmd.arg("+nightly");
     cmd.arg("build");
 
     // Compile for the same target as the parent-lib


### PR DESCRIPTION
This PR performs minimal changes to allow using this crate with `nightly-2021-12-04` again.

It is best reviewed commit by commit.

Closes https://github.com/tlambertz/rftrace/issues/8.

I'll follow up with a bigger modernization of this crate.